### PR TITLE
Create CI/CD pipeline

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cake.tool": {
+      "version": "0.38.5",
+      "commands": [
+        "dotnet-cake"
+      ]
+    }
+  }
+}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,5 +3,7 @@ mode: ContinuousDeployment
 continuous-delivery-fallback-tag: preview
 
 branches:
+  master:
+    regex: ^master$|^main$
   develop:
     tag: vnext

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+max_jobs: 1
+
+image: Visual Studio 2019
+
+cache:
+  - '%LocalAppData%\NuGet\v3-cache'
+
+nuget:
+  account_feed: false
+  project_feed: false
+  disable_publish_on_pr: true
+
+install:
+  - cmd: dotnet tool restore
+
+build_script:
+  - cmd: dotnet cake --target=Full
+
+test: off
+
+artifacts:
+  - path: outputs\*.nupkg
+    name: packages
+  - path: outputs\*.snupkg
+    name: symbols
+  - path: outputs\tests\report
+    name: report
+    type: zip
+
+deploy:
+  - provider: Environment
+    name: MyGet EMG Public
+    on:
+      branch: master
+  - provider: Environment
+    name: NuGet EMG
+    on:
+      branch: master
+      appveyor_repo_tag: true
+  - provider: Environment
+    name: EMG GPR
+    on:
+      branch: master
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,6 @@ test: off
 artifacts:
   - path: outputs\*.nupkg
     name: packages
-  - path: outputs\*.snupkg
-    name: symbols
   - path: outputs\tests\report
     name: report
     type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,14 +31,14 @@ deploy:
   - provider: Environment
     name: MyGet EMG Public
     on:
-      branch: master
+      branch: main
   - provider: Environment
     name: NuGet EMG
     on:
-      branch: master
+      branch: main
       appveyor_repo_tag: true
   - provider: Environment
     name: EMG GPR
     on:
-      branch: master
+      branch: main
       appveyor_repo_tag: true

--- a/build.cake
+++ b/build.cake
@@ -62,7 +62,6 @@ Task("Verify")
         NoRestore = true,
         MSBuildSettings = new DotNetCoreMSBuildSettings()
                             .WithProperty("TreatWarningsAsErrors", "True")
-                            .SetInformationalVersion(state.Version.PackageVersion)
     };
 
     DotNetCoreBuild(state.Paths.SolutionFile.ToString(), settings);

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #tool "nuget:?package=ReportGenerator&version=4.0.5"
-#tool "nuget:?package=JetBrains.dotCover.CommandLineTools&version=2019.2.2"
+#tool "nuget:?package=JetBrains.dotCover.CommandLineTools&version=2020.2.4"
 #tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
 
 var target = Argument("Target", "Full");
@@ -81,8 +81,188 @@ Task("Build")
     DotNetCoreBuild(state.Paths.SolutionFile.ToString(), settings);
 });
 
-RunTarget(target);
+Task("RunTests")
+    .IsDependentOn("Build")
+    .Does<BuildState>(state => 
+{
+    var projectFiles = GetFiles($"{state.Paths.TestFolder}/**/Tests.*.csproj");
 
+    bool success = true;
+
+    foreach (var file in projectFiles)
+    {
+        var targetFrameworks = GetTargetFrameworks(file);
+
+        foreach (var framework in targetFrameworks)
+        {
+            var frameworkFriendlyName = framework.Replace(".", "-");
+
+            try
+            {
+                Information($"Testing {file.GetFilenameWithoutExtension()} ({framework})");
+
+                var testResultFile = state.Paths.TestOutputFolder.CombineWithFilePath($"{file.GetFilenameWithoutExtension()}-{frameworkFriendlyName}.trx");
+                var coverageResultFile = state.Paths.TestOutputFolder.CombineWithFilePath($"{file.GetFilenameWithoutExtension()}-{frameworkFriendlyName}.dcvr");
+
+                var projectFile = MakeAbsolute(file).ToString();
+
+                var dotCoverSettings = new DotCoverCoverSettings()
+                                        .WithFilter("+:type=EMG.*")
+                                        .WithFilter("-:Samples*")
+                                        .WithFilter("-:Tests*")
+                                        .WithFilter("-:TestUtils");
+
+                var settings = new DotNetCoreTestSettings
+                {
+                    NoBuild = true,
+                    NoRestore = true,
+                    Logger = $"trx;LogFileName={testResultFile.FullPath}",
+                    Filter = "TestCategory!=External",
+                    Framework = framework
+                };
+
+                DotCoverCover(c => c.DotNetCoreTest(projectFile, settings), coverageResultFile, dotCoverSettings);
+            }
+            catch (Exception ex)
+            {
+                Error($"There was an error while executing the tests: {file.GetFilenameWithoutExtension()}", ex);
+                success = false;
+            }
+
+            Information("");
+        }
+    }
+    
+    if (!success)
+    {
+        throw new CakeException("There was an error while executing the tests");
+    }
+    
+    if (!success)
+    {
+        throw new CakeException("There was an error while executing the tests");
+    }
+
+    string[] GetTargetFrameworks(FilePath file)
+    {
+        XmlPeekSettings settings = new XmlPeekSettings
+        {
+            SuppressWarning = true
+        };
+
+        return (XmlPeek(file, "/Project/PropertyGroup/TargetFrameworks", settings) ?? XmlPeek(file, "/Project/PropertyGroup/TargetFramework", settings)).Split(";");
+    }
+});
+
+Task("MergeCoverageResults")
+    .IsDependentOn("RunTests")
+    .Does<BuildState>(state =>
+{
+    Information("Merging coverage files");
+    var coverageFiles = GetFiles($"{state.Paths.TestOutputFolder}/*.dcvr");
+    DotCoverMerge(coverageFiles, state.Paths.DotCoverOutputFile);
+    DeleteFiles(coverageFiles);
+});
+
+Task("GenerateXmlReport")
+    .IsDependentOn("MergeCoverageResults")
+    .Does<BuildState>(state =>
+{
+    Information("Generating dotCover XML report");
+    DotCoverReport(state.Paths.DotCoverOutputFile, state.Paths.DotCoverOutputFileXml, new DotCoverReportSettings 
+    {
+        ReportType = DotCoverReportType.DetailedXML
+    });
+});
+
+Task("ExportReport")
+    .IsDependentOn("GenerateXmlReport")
+    .Does<BuildState>(state =>
+{
+    Information("Executing ReportGenerator to generate HTML report");
+    ReportGenerator(state.Paths.DotCoverOutputFileXml, state.Paths.ReportFolder, new ReportGeneratorSettings {
+            ReportTypes = new[]{ReportGeneratorReportType.Html, ReportGeneratorReportType.Xml}
+    });
+});
+
+Task("UploadTestsToAppVeyor")
+    .IsDependentOn("RunTests")
+    .WithCriteria(BuildSystem.IsRunningOnAppVeyor)
+    .Does<BuildState>(state =>
+{
+    Information("Uploading test result files to AppVeyor");
+    var testResultFiles = GetFiles($"{state.Paths.TestOutputFolder}/*.trx");
+
+    foreach (var file in testResultFiles)
+    {
+        Information($"\tUploading {file.GetFilename()}");
+        try
+        {
+            AppVeyor.UploadTestResults(file, AppVeyorTestResultsType.MSTest);
+        }
+        catch 
+        {
+            Error($"Failed to upload {file.GetFilename()}");
+        }
+    }
+});
+
+Task("Test")
+    .IsDependentOn("RunTests")
+    .IsDependentOn("MergeCoverageResults")
+    .IsDependentOn("GenerateXmlReport")
+    .IsDependentOn("ExportReport")
+    .IsDependentOn("UploadTestsToAppVeyor");
+
+Task("PackTool")
+    .IsDependentOn("Version")
+    .IsDependentOn("Restore")
+    .Does<BuildState>(state =>
+{
+    var settings = new DotNetCorePackSettings
+    {
+        Configuration = "Release",
+        NoRestore = true,
+        OutputDirectory = state.Paths.OutputFolder
+    };
+
+    DotNetCorePack(state.Paths.SolutionFile.ToString(), settings);
+});
+
+Task("Pack")
+    .IsDependentOn("PackTool");
+
+Task("UploadPackagesToAppVeyor")
+    .IsDependentOn("Pack")
+    .WithCriteria(BuildSystem.IsRunningOnAppVeyor)
+    .Does<BuildState>(state => 
+{
+    Information("Uploading packages");
+    var files = GetFiles($"{state.Paths.OutputFolder}/*.nukpg");
+
+    foreach (var file in files)
+    {
+        Information($"\tUploading {file.GetFilename()}");
+        AppVeyor.UploadArtifact(file, new AppVeyorUploadArtifactsSettings {
+            ArtifactType = AppVeyorUploadArtifactType.NuGetPackage,
+            DeploymentName = "NuGet"
+        });
+    }
+});
+
+Task("Push")
+    .IsDependentOn("UploadPackagesToAppVeyor");
+
+Task("Full")
+    .IsDependentOn("Version")
+    .IsDependentOn("Restore")
+    .IsDependentOn("Verify")
+    .IsDependentOn("Build")
+    .IsDependentOn("Test")
+    .IsDependentOn("Pack")
+    .IsDependentOn("Push");
+
+RunTarget(target);
 
 public class BuildState
 {

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,120 @@
+#tool "nuget:?package=ReportGenerator&version=4.0.5"
+#tool "nuget:?package=JetBrains.dotCover.CommandLineTools&version=2019.2.2"
+#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0"
+
+var target = Argument("Target", "Full");
+
+Setup<BuildState>(_ => 
+{
+    var state = new BuildState
+    {
+        Paths = new BuildPaths
+        {
+            SolutionFile = MakeAbsolute(File("./DotNetEnsureUnique.sln"))
+        }
+    };
+
+    CleanDirectory(state.Paths.OutputFolder);
+
+    return state;
+});
+
+Task("Version")
+    .Does<BuildState>(state =>
+{
+    var version = GitVersion();
+
+    var packageVersion = version.SemVer;
+    var buildVersion = $"{version.FullSemVer}+{DateTimeOffset.UtcNow:yyyyMMddHHmmss}";
+
+    state.Version = new VersionInfo
+    {
+        PackageVersion = packageVersion,
+        BuildVersion = buildVersion
+    };
+
+
+    Information($"Package version: {state.Version.PackageVersion}");
+    Information($"Build version: {state.Version.BuildVersion}");
+
+    if (BuildSystem.IsRunningOnAppVeyor)
+    {
+        AppVeyor.UpdateBuildVersion(state.Version.BuildVersion);
+    }
+});
+
+Task("Restore")
+    .Does<BuildState>(state =>
+{
+    var settings = new DotNetCoreRestoreSettings
+    {
+
+    };
+
+    DotNetCoreRestore(state.Paths.SolutionFile.ToString(), settings);
+});
+
+Task("Verify")
+    .IsDependentOn("Restore")
+    .Does<BuildState>(state => 
+{
+    var settings = new DotNetCoreBuildSettings
+    {
+        Configuration = "Debug",
+        NoRestore = true,
+        MSBuildSettings = new DotNetCoreMSBuildSettings().WithProperty("TreatWarningsAsErrors", "True")
+    };
+
+    DotNetCoreBuild(state.Paths.SolutionFile.ToString(), settings);
+});
+
+Task("Build")
+    .IsDependentOn("Restore")
+    .Does<BuildState>(state => 
+{
+    var settings = new DotNetCoreBuildSettings
+    {
+        Configuration = "Debug",
+        NoRestore = true
+    };
+
+    DotNetCoreBuild(state.Paths.SolutionFile.ToString(), settings);
+});
+
+RunTarget(target);
+
+
+public class BuildState
+{
+    public VersionInfo Version { get; set; }
+
+    public BuildPaths Paths { get; set; }
+}
+
+public class BuildPaths
+{
+    public FilePath SolutionFile { get; set; }
+
+    public DirectoryPath SolutionFolder => SolutionFile.GetDirectory();
+
+    public DirectoryPath TestFolder => SolutionFolder.Combine("tests");
+
+    public DirectoryPath OutputFolder => SolutionFolder.Combine("outputs");
+
+    public DirectoryPath TestOutputFolder => OutputFolder.Combine("tests");
+
+    public DirectoryPath ReportFolder => TestOutputFolder.Combine("report");
+
+    public FilePath DotCoverOutputFile => TestOutputFolder.CombineWithFilePath("coverage.dcvr");
+
+    public FilePath DotCoverOutputFileXml => TestOutputFolder.CombineWithFilePath("coverage.xml");
+
+    public FilePath OpenCoverResultFile => OutputFolder.CombineWithFilePath("OpenCover.xml");
+}
+
+public class VersionInfo
+{
+    public string PackageVersion { get; set; }
+
+    public string BuildVersion {get; set; }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,10 +5,9 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Configurations>$(Configurations);Verify</Configurations>
     <SkipDefaultEditorConfigAsAdditionalFile>true</SkipDefaultEditorConfigAsAdditionalFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors  Condition=" '$(Configuration)'=='Verify' OR '$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors  Condition=" '$(Configuration)'=='Release'">true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\..\CodeAnalysis.Application.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/EnsureUnique/EnsureUnique.csproj
+++ b/src/EnsureUnique/EnsureUnique.csproj
@@ -13,7 +13,6 @@
     <PackageId>EMG.Tools.EnsureUnique</PackageId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-ensure-unique</ToolCommandName>
-    <PackageVersion>1.0.0</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This PR adds support for a CI/CD pipeline based on
- [Cake](https://cakebuild.net/)
- [AppVeyor](https://www.appveyor.com/)
- [GitVersion](https://gitversion.net/)
- [JetBrains dotCover](https://www.jetbrains.com/dotcover/)
- [ReportGenerator](https://danielpalme.github.io/ReportGenerator/)